### PR TITLE
use unique real UDP ports in tests so we avoid potential port reuse conflicts

### DIFF
--- a/layers/link/ethernet_port_test.go
+++ b/layers/link/ethernet_port_test.go
@@ -19,8 +19,8 @@ func TestConnectedPorts(t *testing.T) {
 	port1, err := link.NewEthernetPort(context.Background(), link.EthernetPortConfig{
 		MACAddress: port1MAC.String(),
 		Medium: physical.FullDuplexUnreliablePortConfig{
-			RecvUDPEndpoint: ":50001",
-			SendUDPEndpoint: ":50002",
+			RecvUDPEndpoint: ":50021",
+			SendUDPEndpoint: ":50022",
 		},
 	})
 	require.NoError(t, err)
@@ -32,8 +32,8 @@ func TestConnectedPorts(t *testing.T) {
 	port2, err := link.NewEthernetPort(context.Background(), link.EthernetPortConfig{
 		MACAddress: port2MAC.String(),
 		Medium: physical.FullDuplexUnreliablePortConfig{
-			RecvUDPEndpoint: ":50002",
-			SendUDPEndpoint: ":50001",
+			RecvUDPEndpoint: ":50022",
+			SendUDPEndpoint: ":50021",
 		},
 	})
 	require.NoError(t, err)
@@ -72,8 +72,8 @@ func TestWrongDstMACAddress(t *testing.T) {
 	port1, err := link.NewEthernetPort(context.Background(), link.EthernetPortConfig{
 		MACAddress: port1MAC.String(),
 		Medium: physical.FullDuplexUnreliablePortConfig{
-			RecvUDPEndpoint: ":50001",
-			SendUDPEndpoint: ":50002",
+			RecvUDPEndpoint: ":50031",
+			SendUDPEndpoint: ":50032",
 		},
 	})
 	require.NoError(t, err)
@@ -84,8 +84,8 @@ func TestWrongDstMACAddress(t *testing.T) {
 	port2, err := link.NewEthernetPort(context.Background(), link.EthernetPortConfig{
 		MACAddress: port2MAC.String(),
 		Medium: physical.FullDuplexUnreliablePortConfig{
-			RecvUDPEndpoint: ":50002",
-			SendUDPEndpoint: ":50001",
+			RecvUDPEndpoint: ":50032",
+			SendUDPEndpoint: ":50031",
 		},
 	})
 	require.NoError(t, err)
@@ -127,8 +127,8 @@ func TestBroadcastMACAddress(t *testing.T) {
 	port1, err := link.NewEthernetPort(context.Background(), link.EthernetPortConfig{
 		MACAddress: port1MAC.String(),
 		Medium: physical.FullDuplexUnreliablePortConfig{
-			RecvUDPEndpoint: ":50001",
-			SendUDPEndpoint: ":50002",
+			RecvUDPEndpoint: ":50041",
+			SendUDPEndpoint: ":50042",
 		},
 	})
 	require.NoError(t, err)
@@ -139,8 +139,8 @@ func TestBroadcastMACAddress(t *testing.T) {
 	port2, err := link.NewEthernetPort(context.Background(), link.EthernetPortConfig{
 		MACAddress: port2MAC.String(),
 		Medium: physical.FullDuplexUnreliablePortConfig{
-			RecvUDPEndpoint: ":50002",
-			SendUDPEndpoint: ":50001",
+			RecvUDPEndpoint: ":50042",
+			SendUDPEndpoint: ":50041",
 		},
 	})
 	require.NoError(t, err)
@@ -168,8 +168,8 @@ func TestForwardingMode(t *testing.T) {
 	port1, err := link.NewEthernetPort(context.Background(), link.EthernetPortConfig{
 		MACAddress: port1MAC.String(),
 		Medium: physical.FullDuplexUnreliablePortConfig{
-			RecvUDPEndpoint: ":50001",
-			SendUDPEndpoint: ":50002",
+			RecvUDPEndpoint: ":50051",
+			SendUDPEndpoint: ":50052",
 		},
 	})
 	require.NoError(t, err)
@@ -181,8 +181,8 @@ func TestForwardingMode(t *testing.T) {
 		ForwardingMode: true,
 		MACAddress:     port2MAC.String(),
 		Medium: physical.FullDuplexUnreliablePortConfig{
-			RecvUDPEndpoint: ":50002",
-			SendUDPEndpoint: ":50001",
+			RecvUDPEndpoint: ":50052",
+			SendUDPEndpoint: ":50051",
 		},
 	})
 	require.NoError(t, err)

--- a/layers/link/switch_test.go
+++ b/layers/link/switch_test.go
@@ -18,22 +18,22 @@ var (
 			{
 				MACAddress: "00:00:5e:00:53:aa",
 				Medium: physical.FullDuplexUnreliablePortConfig{
-					RecvUDPEndpoint: ":50001",
-					SendUDPEndpoint: ":50101",
+					RecvUDPEndpoint: ":50061",
+					SendUDPEndpoint: ":50161",
 				},
 			},
 			{
 				MACAddress: "00:00:5e:00:53:ab",
 				Medium: physical.FullDuplexUnreliablePortConfig{
-					RecvUDPEndpoint: ":50002",
-					SendUDPEndpoint: ":50102",
+					RecvUDPEndpoint: ":50062",
+					SendUDPEndpoint: ":50162",
 				},
 			},
 			{
 				MACAddress: "00:00:5e:00:53:ac",
 				Medium: physical.FullDuplexUnreliablePortConfig{
-					RecvUDPEndpoint: ":50003",
-					SendUDPEndpoint: ":50103",
+					RecvUDPEndpoint: ":50063",
+					SendUDPEndpoint: ":50163",
 				},
 			},
 		},
@@ -43,22 +43,22 @@ var (
 		{
 			MACAddress: "00:00:5e:01:53:aa",
 			Medium: physical.FullDuplexUnreliablePortConfig{
-				RecvUDPEndpoint: ":50101",
-				SendUDPEndpoint: ":50001",
+				RecvUDPEndpoint: ":50161",
+				SendUDPEndpoint: ":50061",
 			},
 		},
 		{
 			MACAddress: "00:00:5e:01:53:ab",
 			Medium: physical.FullDuplexUnreliablePortConfig{
-				RecvUDPEndpoint: ":50102",
-				SendUDPEndpoint: ":50002",
+				RecvUDPEndpoint: ":50162",
+				SendUDPEndpoint: ":50062",
 			},
 		},
 		{
 			MACAddress: "00:00:5e:01:53:ac",
 			Medium: physical.FullDuplexUnreliablePortConfig{
-				RecvUDPEndpoint: ":50103",
-				SendUDPEndpoint: ":50003",
+				RecvUDPEndpoint: ":50163",
+				SendUDPEndpoint: ":50063",
 			},
 		},
 	}

--- a/layers/network/end_system_test.go
+++ b/layers/network/end_system_test.go
@@ -28,8 +28,8 @@ var (
 				Card: link.EthernetPortConfig{
 					MACAddress: "00:00:5e:00:53:aa",
 					Medium: physical.FullDuplexUnreliablePortConfig{
-						RecvUDPEndpoint: ":50001",
-						SendUDPEndpoint: ":50101",
+						RecvUDPEndpoint: ":50081",
+						SendUDPEndpoint: ":50181",
 					},
 				},
 			},
@@ -45,8 +45,8 @@ var (
 		Card: link.EthernetPortConfig{
 			MACAddress: "00:00:5e:01:53:aa",
 			Medium: physical.FullDuplexUnreliablePortConfig{
-				RecvUDPEndpoint: ":50101",
-				SendUDPEndpoint: ":50001",
+				RecvUDPEndpoint: ":50181",
+				SendUDPEndpoint: ":50081",
 			},
 		},
 	}

--- a/layers/network/interface_test.go
+++ b/layers/network/interface_test.go
@@ -20,22 +20,22 @@ var (
 			{
 				MACAddress: "00:00:5e:00:53:aa",
 				Medium: physical.FullDuplexUnreliablePortConfig{
-					RecvUDPEndpoint: ":50001",
-					SendUDPEndpoint: ":50101",
+					RecvUDPEndpoint: ":50071",
+					SendUDPEndpoint: ":50171",
 				},
 			},
 			{
 				MACAddress: "00:00:5e:00:53:ab",
 				Medium: physical.FullDuplexUnreliablePortConfig{
-					RecvUDPEndpoint: ":50002",
-					SendUDPEndpoint: ":50102",
+					RecvUDPEndpoint: ":50072",
+					SendUDPEndpoint: ":50172",
 				},
 			},
 			{
 				MACAddress: "00:00:5e:00:53:ac",
 				Medium: physical.FullDuplexUnreliablePortConfig{
-					RecvUDPEndpoint: ":50003",
-					SendUDPEndpoint: ":50103",
+					RecvUDPEndpoint: ":50073",
+					SendUDPEndpoint: ":50173",
 				},
 			},
 		},
@@ -49,8 +49,8 @@ var (
 			Card: link.EthernetPortConfig{
 				MACAddress: "00:00:5e:01:53:aa",
 				Medium: physical.FullDuplexUnreliablePortConfig{
-					RecvUDPEndpoint: ":50101",
-					SendUDPEndpoint: ":50001",
+					RecvUDPEndpoint: ":50171",
+					SendUDPEndpoint: ":50071",
 				},
 			},
 		},
@@ -60,8 +60,8 @@ var (
 			Card: link.EthernetPortConfig{
 				MACAddress: "00:00:5e:01:53:ab",
 				Medium: physical.FullDuplexUnreliablePortConfig{
-					RecvUDPEndpoint: ":50102",
-					SendUDPEndpoint: ":50002",
+					RecvUDPEndpoint: ":50172",
+					SendUDPEndpoint: ":50072",
 				},
 			},
 		},
@@ -71,8 +71,8 @@ var (
 			Card: link.EthernetPortConfig{
 				MACAddress: "00:00:5e:01:53:ac",
 				Medium: physical.FullDuplexUnreliablePortConfig{
-					RecvUDPEndpoint: ":50103",
-					SendUDPEndpoint: ":50003",
+					RecvUDPEndpoint: ":50173",
+					SendUDPEndpoint: ":50073",
 				},
 			},
 		},

--- a/layers/network/router_test.go
+++ b/layers/network/router_test.go
@@ -26,8 +26,8 @@ var (
 			Card: link.EthernetPortConfig{
 				MACAddress: "00:00:5e:00:53:aa",
 				Medium: physical.FullDuplexUnreliablePortConfig{
-					RecvUDPEndpoint: ":50001",
-					SendUDPEndpoint: ":50101",
+					RecvUDPEndpoint: ":50091",
+					SendUDPEndpoint: ":50191",
 				},
 			},
 		},
@@ -39,8 +39,8 @@ var (
 			Card: link.EthernetPortConfig{
 				MACAddress: "00:00:5e:00:53:ab",
 				Medium: physical.FullDuplexUnreliablePortConfig{
-					RecvUDPEndpoint: ":50002",
-					SendUDPEndpoint: ":50102",
+					RecvUDPEndpoint: ":50092",
+					SendUDPEndpoint: ":50192",
 				},
 			},
 		},
@@ -55,8 +55,8 @@ var (
 			Card: link.EthernetPortConfig{
 				MACAddress: "00:00:5e:01:53:aa",
 				Medium: physical.FullDuplexUnreliablePortConfig{
-					RecvUDPEndpoint: ":50101",
-					SendUDPEndpoint: ":50001",
+					RecvUDPEndpoint: ":50191",
+					SendUDPEndpoint: ":50091",
 				},
 			},
 		},
@@ -68,8 +68,8 @@ var (
 			Card: link.EthernetPortConfig{
 				MACAddress: "00:00:5e:01:53:ab",
 				Medium: physical.FullDuplexUnreliablePortConfig{
-					RecvUDPEndpoint: ":50102",
-					SendUDPEndpoint: ":50002",
+					RecvUDPEndpoint: ":50192",
+					SendUDPEndpoint: ":50092",
 				},
 			},
 		},

--- a/layers/physical/full_duplex_unreliable_port_test.go
+++ b/layers/physical/full_duplex_unreliable_port_test.go
@@ -53,15 +53,15 @@ func TestConnectedPorts(t *testing.T) {
 
 func TestReadLessBytesThanBufSize(t *testing.T) {
 	port1, err := physical.NewFullDuplexUnreliablePort(context.Background(), physical.FullDuplexUnreliablePortConfig{
-		RecvUDPEndpoint: ":50001",
-		SendUDPEndpoint: ":50002",
+		RecvUDPEndpoint: ":50011",
+		SendUDPEndpoint: ":50012",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, port1)
 
 	port2, err := physical.NewFullDuplexUnreliablePort(context.Background(), physical.FullDuplexUnreliablePortConfig{
-		RecvUDPEndpoint: ":50002",
-		SendUDPEndpoint: ":50001",
+		RecvUDPEndpoint: ":50012",
+		SendUDPEndpoint: ":50011",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, port2)


### PR DESCRIPTION
fixes #27 